### PR TITLE
Use env vars for Supabase

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+.env*

--- a/src/supabaseClient.js
+++ b/src/supabaseClient.js
@@ -1,7 +1,7 @@
 
 import { createClient } from '@supabase/supabase-js';
 
-const supabaseUrl = 'https://nbsrkypcjkevncgzepqs.supabase.co';
-const supabaseKey = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Im5ic3JreXBjamtldm5jZ3plcHFzIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTAzNDI1NDAsImV4cCI6MjA2NTkxODU0MH0.eIrHOXCzCfquju-LJibDjZZfVLt4hPQMNitY1kaO8jE'; 
+const supabaseUrl = import.meta.env.VITE_SUPABASE_URL;
+const supabaseKey = import.meta.env.VITE_SUPABASE_KEY;
 
 export const supabase = createClient(supabaseUrl, supabaseKey);


### PR DESCRIPTION
## Summary
- hide Supabase credentials in `.env.local`
- load Supabase URL and key from `import.meta.env`
- ignore `.env*` files in Git

## Testing
- `npm run build` *(fails: Cannot find module '@rollup/rollup-linux-x64-gnu')*

------
https://chatgpt.com/codex/tasks/task_e_685bf5e77708832da4bf8648fa5a2e87